### PR TITLE
Remove resolveIndexFeed rpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,21 +114,6 @@ operator could be `isPrivate` or `isBox2` but extreme care must be
 taken not to leak information using these queries around private
 information.
 
-## resolveIndexFeed(feedId): source
-
-A method to get an index feeds and the messages referenced. The aim of
-this RPC is for onboarding light clients that want to use indexes to
-only download a particular indexed subset of messages. Clients that
-store the indexed messages in full but still want to index feed can
-use normal replications methods such as `createHistoryStream` and
-`getSubset`.
-
-Result:
-
-```
-[{  msg: msg1, indexed: origMsg }, ...],
-```
-
 ## getTangle (TBD)
 
 Tangles in SSB behave differently than other types of messages in


### PR DESCRIPTION
As explained in https://github.com/ssb-ngi-pointer/ssb-secure-partial-replication-spec, we will be using EBT for indexes instead.